### PR TITLE
Pin xtask version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rstest = "0.2.1"
 strum = { version = "0.26.3", features = ["derive"] }
 
 ### For xtask crate ###
-tracel-xtask = { version = "~1.1" }
+tracel-xtask = { version = "=1.1.8" }
 
 [profile.dev]
 debug = 0 # Speed up compilation time and not necessary.


### PR DESCRIPTION
Turns out that maintenance is way better by pining our xtask crate rather than allowing auto-update.