### PR TITLE
Remove the default feature from cubecl-hip-sys Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,16 @@ jobs:
   checks:
     runs-on: amd-rx7600
     steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v1.8
+      # --------------------------------------------------------------------------------
+      # We don't use our github-action because it seems that the cache does not work well
+      # with our AMD runner.
+      # cargo-audit is not found for example whereas it is correctly installed.
+      - name: install rust
+        uses: dtolnay/rust-toolchain@master
         with:
-          rust-toolchain: stable
-          cache-key: stable-linux
-          linux-pre-cleanup: false
-    # --------------------------------------------------------------------------------
+          components: rustfmt, clippy
+          toolchain: stable
+      # --------------------------------------------------------------------------------
       - name: Audit
         run: cargo xtask check audit
       # --------------------------------------------------------------------------------
@@ -39,12 +42,12 @@ jobs:
   tests:
     runs-on: amd-rx7600
     steps:
-      - name: Setup Rust
-        uses: tracel-ai/github-actions/setup-rust@v1.8
+      # --------------------------------------------------------------------------------
+      - name: install rust
+        uses: dtolnay/rust-toolchain@master
         with:
-          rust-toolchain: stable
-          cache-key: stable-linux
-          linux-pre-cleanup: false
+          components: rustfmt, clippy
+          toolchain: stable
       # --------------------------------------------------------------------------------
       - name: Lint
         run: cargo xtask check lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
       # We don't use our github-action because it seems that the cache does not work well
       # with our AMD runner.
       # cargo-audit is not found for example whereas it is correctly installed.
+      - name: checkout
+        uses: actions/checkout@v4
       - name: install rust
         uses: dtolnay/rust-toolchain@master
         with:
@@ -43,6 +45,8 @@ jobs:
     runs-on: amd-rx7600
     steps:
       # --------------------------------------------------------------------------------
+      - name: checkout
+        uses: actions/checkout@v4
       - name: install rust
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,6 @@ env:
   TYPOS_LINK: "https://github.com/crate-ci/typos/releases/download"
   TYPOS_VERSION: "1.23.4"
   CUBECL_ROCM_PATH: "/opt/rocm"
-  # Change ROCm version and HIP bindings version here
-  # The combination must match what is declared in crates/cubecl-hip-sys/Cargo.toml
-  CARGO_FEATURE_ROCM__6_3_1: "1"
-  CARGO_FEATURE_HIP_42133: "1"
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ env:
   TYPOS_LINK: "https://github.com/crate-ci/typos/releases/download"
   TYPOS_VERSION: "1.23.4"
   CUBECL_ROCM_PATH: "/opt/rocm"
+  # Change ROCm version and HIP bindings version here
+  # The combination must match what is declared in crates/cubecl-hip-sys/Cargo.toml
+  CARGO_FEATURE_ROCM__6_3_1: "1"
+  CARGO_FEATURE_HIP_42133: "1"
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,7 +172,7 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cubecl-hip-sys"
-version = "6.3.0"
+version = "6.3.1000"
 dependencies = [
  "libc",
  "rstest",

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ If a fix is required and the default ROCm version remains `6.2.4`, the `cubecl-h
 
 Add the crate [cubecl-hip-sys][2] to the `Cargo.toml` of your project and enable the feature
 corresponding to the version of ROCm you have installed.
-If you no feature corresponds to your ROCm installation then read the next section to learn
+
+```toml
+cubecl-hip-sys = { version = "6.3.1000", features = ["rocm__6_3_1"] }
+```
+
+If no feature corresponds to your ROCm installation then read the next section to learn
 how to generate and submit new bindings for your version.
 
 Next you need to point out where you installed ROCm so that `rustc` can link to your ROCM libraries. To do so set the variable `ROCM_PATH`, or `HIP_PATH` or the more specific `CUBECL_ROCM_PATH` to its

--- a/crates/cubecl-hip-sys/Cargo.toml
+++ b/crates/cubecl-hip-sys/Cargo.toml
@@ -12,7 +12,7 @@ version.workspace = true
 rust-version = "1.81"
 
 [features]
-default = ["rocm__6_3_1"]
+default = []
 
 # ROCm versions
 rocm__6_2_2 = [ "hip_41134" ]

--- a/crates/cubecl-hip-sys/build.rs
+++ b/crates/cubecl-hip-sys/build.rs
@@ -21,7 +21,6 @@ fn is_rocm_feature_set() -> bool {
     !enabled_features.is_empty()
 }
 
-
 /// Make sure that at least one and only one rocm version feature is set
 fn ensure_single_rocm_version_feature_set() {
     let mut enabled_features = Vec::new();
@@ -111,8 +110,14 @@ fn set_default_rocm_version(rocm_path: impl AsRef<Path>) -> std::io::Result<()> 
     let default_hip_feature = format!("hip_{}", hip_system_patch.patch);
     println!("cargo:rustc-cfg=feature=\"{}\"", default_rocm_feature);
     println!("cargo:rustc-cfg=feature=\"{}\"", default_hip_feature);
-    env::set_var(format!("{ROCM_FEATURE_PREFIX}{}", rocm_system_version).replace(".", "_"), "1");
-    env::set_var(format!("{ROCM_HIP_FEATURE_PREFIX}{}", hip_system_patch.patch), "1");
+    env::set_var(
+        format!("{ROCM_FEATURE_PREFIX}{}", rocm_system_version).replace(".", "_"),
+        "1",
+    );
+    env::set_var(
+        format!("{ROCM_HIP_FEATURE_PREFIX}{}", hip_system_patch.patch),
+        "1",
+    );
     Ok(())
 }
 


### PR DESCRIPTION
The default feature to select a default version of ROCm prevents users from easily choosing a different version in Burn.

Part of the fix for Burn discussion https://github.com/tracel-ai/burn/discussions/2709